### PR TITLE
read file and eval it, instead of requiring

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,8 +37,10 @@ var readfileFunc = function (path) {
       return _.merge(data, overrides || {})
     }
   }
-
-  var loader = {".json": readJSON, ".js": require.bind(require, path)}
+  var loader = {
+    ".json": readJSON,
+    ".js": function () { return eval(fs.readFileSync(path, "utf8")) }
+  }
   return loader[Path.extname(path)]()
 }
 


### PR DESCRIPTION
seems like mock-fs does not mock require in node5
